### PR TITLE
Fixed type hints for optional params.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -158,3 +158,5 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+.DS_Store

--- a/photerr/euclid.py
+++ b/photerr/euclid.py
@@ -32,6 +32,7 @@ class EuclidErrorParams(ErrorParams):
             "H": 0.04,
         }
     )
+    
     m5: Dict[str, float] = field(
         default_factory=lambda: {
             "Y": 24.0,

--- a/photerr/lsst.py
+++ b/photerr/lsst.py
@@ -1,6 +1,6 @@
 """Photometric error model for LSST."""
 from dataclasses import dataclass, field
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 from photerr.model import ErrorModel
 from photerr.params import ErrorParams, param_docstring
@@ -15,7 +15,6 @@ class LsstErrorParams(ErrorParams):
 
     __doc__ += param_docstring
 
-    tvis: float = 30.0
     nYrObs: float = 10.0
     nVisYr: Dict[str, float] = field(
         default_factory=lambda: {
@@ -37,8 +36,11 @@ class LsstErrorParams(ErrorParams):
             "y": 0.039,
         }
     )
-    airmass: float = 1.2
+
     m5: Dict[str, float] = field(default_factory=lambda: {})
+
+    tvis: Optional[float] = 30.0
+    airmass: Optional[float] = 1.2
     Cm: Dict[str, float] = field(
         default_factory=lambda: {
             "u": 23.09,

--- a/photerr/params.py
+++ b/photerr/params.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from copy import deepcopy
 from dataclasses import InitVar, dataclass, field
-from typing import Any, Dict, Union
+from typing import Any, Dict, Optional, Union
 
 import numpy as np
 
@@ -185,8 +185,8 @@ class ErrorParams:
 
     m5: Dict[str, float] = field(default_factory=lambda: {})
 
-    tvis: float = None  # type: ignore
-    airmass: float = None  # type: ignore
+    tvis: Optional[float] = None  
+    airmass: Optional[float] = None  
     Cm: Dict[str, float] = field(default_factory=lambda: {})
     msky: Dict[str, float] = field(default_factory=lambda: {})
     theta: Dict[str, float] = field(default_factory=lambda: {})
@@ -211,7 +211,7 @@ class ErrorParams:
 
     errLoc: str = "after"
 
-    renameDict: InitVar[Dict[str, str]] = None
+    renameDict: InitVar[Optional[Dict[str, str]]] = None
     validate: InitVar[bool] = True
 
     def __post_init__(

--- a/photerr/roman.py
+++ b/photerr/roman.py
@@ -34,6 +34,7 @@ class RomanErrorParams(ErrorParams):
             "F": 0.04,
         }
     )
+    
     m5: Dict[str, float] = field(
         default_factory=lambda: {
             "Y": 26.9,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "photerr"
-version = "1.1.0"
+version = "1.1.1"
 description = "Photometric error model for astronomical imaging surveys"
 authors = ["John Franklin Crenshaw <jfcrenshaw@gmail.com>"]
 readme = "README.md"


### PR DESCRIPTION
For optional error parameters, changed type hints from `type` to `Optional[type]`.